### PR TITLE
Tie physics to FPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,8 +36,6 @@
 *.user
 *.pdb
 *.idb
-*.manifest
-*.htm
 *.res
 *.ilk
 *.dep

--- a/Blocks3D.exe.manifest
+++ b/Blocks3D.exe.manifest
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+	<assemblyIdentity
+		version="0.0.105.1"
+		processorArchitecture="*"
+		name="Blocks3D.Blocks3D.Blocks3D"
+		type="win32"
+	/>
+	<dependency>
+		<dependentAssembly>
+			<assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*"/>
+		</dependentAssembly>
+	</dependency>
+</assembly>

--- a/Dialogs.rc
+++ b/Dialogs.rc
@@ -47,5 +47,7 @@ IDI_ICON1          ICON           "FatB3dIcon.ico"
 //
 // Manifest resources
 //
+#ifndef _DEBUG
 LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
 1				RT_MANIFEST    ".\\Blocks3D.exe.manifest"
+#endif

--- a/src/source/Application.cpp
+++ b/src/source/Application.cpp
@@ -353,7 +353,7 @@ void Application::onSimulation(RealTime rdt, SimTime sdt, SimTime idt) {
 		}
 		for(int i = 0; i < 6; i++)
 		{
-			_dataModel->getEngine()->step(sdt*2);
+			_dataModel->getEngine()->step(0.1F);
 		}
 		onLogic();
 		

--- a/src/source/main.cpp
+++ b/src/source/main.cpp
@@ -148,7 +148,9 @@ LRESULT CALLBACK G3DProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 
 
 int main(int argc, char** argv) {
+#ifndef _DEBUG
 	try{
+#endif
 		hresult = OleInitialize(NULL);
 
 /*		IInternetSecurityManager *pSecurityMgr;
@@ -214,10 +216,12 @@ int main(int argc, char** argv) {
 		Globals::mainHwnd = hwndMain;
 		Application app = Application(hwndMain);
 		app.run();	
+#ifndef _DEBUG
 	}
 	catch(...)
 	{
 		OnError(-1);
 	}
+#endif
     return 0;
 }


### PR DESCRIPTION
Prevents physics from exploding when the window is moved

Also:

- Made crash dialog not replace access violation exceptions on debug
- Updated gitignore to not ignore manifest or htm files
